### PR TITLE
fire a window resize after rendering features

### DIFF
--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -46,5 +46,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 maxZoom: 14
             });
         });
+        window.dispatchEvent(new Event('resize'));
     }
 });


### PR DESCRIPTION
This plugin is really useful, but I hit a very frustrating issue with it:

As it stands, when I use it to render a polygon column, only the last row will have its polygon inside the desired viewport. All the other rows end up with the map offset from the intended centre. This screen capture shows an example of this behaviour. I get the same behaviour in firefox and chrome.

![GIFrecord_2019-10-13_154418](https://user-images.githubusercontent.com/6025893/66720166-3f839500-edf1-11e9-82ab-0ec7a065f4c5.gif)

This issue doesn't reproduce when the geometry is a Point.

I tried various ways to resolve this (changed the rendering order, moved the `map.fitBounds()` inside a `layer.add` event or a `map.addlayer` event handler, declared a new layer var each time through the loop, etc). None fo those were effective. The one thing I found did work was spoofing a window resize event that doesn't actually change the window size after all the maps are rendered. This has the effect of redrawing all the maps which then centers them all correctly, as shown in this screen capture:

![GIFrecord_2019-10-13_154629](https://user-images.githubusercontent.com/6025893/66720172-43afb280-edf1-11e9-9228-69058b356fd6.gif)

This is a rather unsatisfying fix as it doesn't really address the underlying issue, but it does at least offer a workaround.