### PR TITLE
add config options for tile_layer and tile_layer_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ You can change this limit using the `default_maps_to_load` plugin configuration 
 }
 ```
 Then run Datasette with `datasette mydb.db -m metadata.json`.
+
+There are options for custom tile layers the same way as in <https://github.com/simonw/datasette-cluster-map#custom-tile-layers>.

--- a/datasette_leaflet_geojson/__init__.py
+++ b/datasette_leaflet_geojson/__init__.py
@@ -1,6 +1,13 @@
 from datasette import hookimpl
 import json
 
+TILE_LAYER = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+TILE_LAYER_OPTIONS = {
+    "maxZoom": 19,
+    "detectRetina": True,
+    "attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+}
+
 GEOJSON_TYPES = {
     "Point",
     "MultiPoint",
@@ -65,6 +72,21 @@ def extra_body_script(datasette, database, table):
         )
         or {}
     )
-    return "window.DATASETTE_LEAFLET_GEOJSON_DEFAULT_MAPS_TO_LOAD = {};".format(
-        json.dumps(config.get("default_maps_to_load") or 10)
+
+    js = []
+    js.append(
+        "window.DATASETTE_LEAFLET_GEOJSON_DEFAULT_MAPS_TO_LOAD = {};".format(
+            json.dumps(config.get("default_maps_to_load") or 10)
+        )
     )
+    js.append(
+        "window.DATASETTE_CLUSTER_MAP_TILE_LAYER = {};".format(
+            json.dumps(config.get("tile_layer") or TILE_LAYER)
+        )
+    )
+    js.append(
+        "window.DATASETTE_CLUSTER_MAP_TILE_LAYER_OPTIONS = {};".format(
+            json.dumps(config.get("tile_layer_options") or TILE_LAYER_OPTIONS)
+        )
+    )
+    return "\n".join(js)

--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -35,9 +35,6 @@ document.addEventListener("DOMContentLoaded", () => {
     "Feature",
     "FeatureCollection",
   ]);
-  const attribution =
-    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
-  const tilesUrl = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
 
   function upgradeTd({ td, data }, activate) {
     // OK, it should be GeoJSON - display it with leaflet
@@ -54,11 +51,9 @@ document.addEventListener("DOMContentLoaded", () => {
     function addMap() {
       let map = L.map(el, {
         layers: [
-          L.tileLayer(tilesUrl, {
-            maxZoom: 19,
-            detectRetina: true,
-            attribution: attribution,
-          }),
+          L.tileLayer(
+          window.DATASETTE_CLUSTER_MAP_TILE_LAYER,
+          window.DATASETTE_CLUSTER_MAP_TILE_LAYER_OPTIONS),
         ],
       });
       let layer = L.geoJSON(data);


### PR DESCRIPTION
I wanted to use [statiamaps](https://stadiamaps.com/) in Datasette but in this plugin the tile_layer is set in the js-file.
This change adds TILE_LAYER and TILE_LAYER_OPTIONS the same way as in <https://github.com/simonw/datasette-cluster-map>.

example usage with stadiamaps in metadata.yml:
```yml
---
plugins:
  datasette-leaflet-geojson:
    tile_layer: "https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}{r}.png?api_key=YOUR_API_KEY"
    tile_layer_options:
      attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors'
      maxZoom: 20

```