### PR TITLE
Add try/catch around resize event

### DIFF
--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -124,6 +124,10 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
     }
-    window.dispatchEvent(new Event("resize"));
+    // don't throw an error if another JS library expect Events to be attached to the DOM.
+    // Happens with Plot/D3
+    try {
+      window.dispatchEvent(new Event("resize"));
+    } catch {}
   }
 });


### PR DESCRIPTION
This came up with `datasette-plot`: There, D3 catches all Event dispatches, but since this Event isn't attached to the DOM (and instead is on the Window object), it throws an error. 

But, since manual `.dispatchEvent()` events [are handle synchronously](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent#:~:text=Unlike%20%22native%22%20events%2C%20which%20are%20fired%20by%20the%20browser%20and%20invoke%20event%20handlers%20asynchronously%20via%20the%20event%20loop%2C%20dispatchEvent()%20invokes%20event%20handlers%20synchronously.%20All%20applicable%20event%20handlers%20are%20called%20and%20return%20before%20dispatchEvent()%20returns.), that error would happen right away in `datasette-leaflet-geojson`, preventing other JavaScript plugins to work correctly.