### PR TITLE
Better error handling when creating maps

### DIFF
--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -52,23 +52,24 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     td.appendChild(el);
     function addMap() {
-      let map = L.map(el, {
-        layers: [
-          L.tileLayer(tilesUrl, {
-            maxZoom: 19,
-            detectRetina: true,
-            attribution: attribution,
-          }),
-        ],
-      });
+      var map = null;
       try {
+        map = L.map(el, {
+          layers: [
+            L.tileLayer(tilesUrl, {
+              maxZoom: 19,
+              detectRetina: true,
+              attribution: attribution,
+            }),
+          ],
+        });
         let layer = L.geoJSON(data);
         layer.addTo(map);
         map.fitBounds(layer.getBounds(), {
           maxZoom: 14,
         });
       } catch (error) {
-        console.warn("GeoJSON parse failed", data, error);
+        console.warn("Map creation failed", data, error);
         let div = document.createElement("div");
         div.innerHTML = "Error while displaying map: " + error;
         div.style.color = "#666";
@@ -77,7 +78,7 @@ document.addEventListener("DOMContentLoaded", () => {
         div.style.alignItems = "center";
         div.style.height = "400px";
 
-        map.remove();
+        if (map) { map.remove(); }
         el.appendChild(div);
       }
     }

--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -61,11 +61,25 @@ document.addEventListener("DOMContentLoaded", () => {
           }),
         ],
       });
-      let layer = L.geoJSON(data);
-      layer.addTo(map);
-      map.fitBounds(layer.getBounds(), {
-        maxZoom: 14,
-      });
+      try {
+        let layer = L.geoJSON(data);
+        layer.addTo(map);
+        map.fitBounds(layer.getBounds(), {
+          maxZoom: 14,
+        });
+      } catch (error) {
+        console.warn("GeoJSON parse failed", data, error);
+        let div = document.createElement("div");
+        div.innerHTML = "Error while displaying map: " + error;
+        div.style.color = "#666";
+        div.style.display = "flex";
+        div.style.justifyContent = "center";
+        div.style.alignItems = "center";
+        div.style.height = "400px";
+
+        map.remove();
+        el.appendChild(div);
+      }
     }
     if (activate) {
       addMap();

--- a/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
+++ b/datasette_leaflet_geojson/static/datasette-leaflet-geojson.js
@@ -116,11 +116,15 @@ document.addEventListener("DOMContentLoaded", () => {
       loadDependencies(() => {
         let numDone = 0;
         tdsToUpgrade.forEach((item) => {
-          upgradeTd(
-            item,
-            numDone < window.DATASETTE_LEAFLET_GEOJSON_DEFAULT_MAPS_TO_LOAD
-          );
-          numDone += 1;
+          try {
+            upgradeTd(
+              item,
+              numDone < window.DATASETTE_LEAFLET_GEOJSON_DEFAULT_MAPS_TO_LOAD
+            );
+            numDone += 1;
+          } catch (error) {
+            console.warn("Failed to add map for", item, error);
+          }
         });
       });
     }


### PR DESCRIPTION
This modifies `addMap` to display an error message in case anything fails while creating the map. This fixes an issue where invalid GeoJSON would prevent maps in "later" rows from being displayed.